### PR TITLE
MLP-5115: fix sync race in cache

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -723,6 +723,10 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	sc.informerFactory.Start(stopCh)
 	sc.vcInformerFactory.Start(stopCh)
 	sc.WaitForCacheSync(stopCh)
+	for i := 0; i < int(sc.nodeWorkers); i++ {
+		go wait.Until(sc.runNodeWorker, 0, stopCh)
+	}
+
 	// We have to wait until all nodes are handled
 	// If we don't, the total amount of guaranteed resources might be greater
 	// than the total amount of resources
@@ -730,9 +734,6 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	klog.V(3).Info("wait for nodes sync")
 	sc.WaitForNodesSync()
 	klog.V(3).Info("node sync finished")
-	for i := 0; i < int(sc.nodeWorkers); i++ {
-		go wait.Until(sc.runNodeWorker, 0, stopCh)
-	}
 
 	// Re-sync error tasks.
 	go wait.Until(sc.processResyncTask, 0, stopCh)

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -723,6 +723,12 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	sc.informerFactory.Start(stopCh)
 	sc.vcInformerFactory.Start(stopCh)
 	sc.WaitForCacheSync(stopCh)
+	// We have to wait until all nodes are handled
+	// If we don't total amount of guaranted resources might be gretear than
+	// total amount of resources
+	// Can use busy loop because this method is called only once
+	for sc.nodeQueue.Len() != 0 {
+	}
 	for i := 0; i < int(sc.nodeWorkers); i++ {
 		go wait.Until(sc.runNodeWorker, 0, stopCh)
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -724,11 +724,12 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 	sc.vcInformerFactory.Start(stopCh)
 	sc.WaitForCacheSync(stopCh)
 	// We have to wait until all nodes are handled
-	// If we don't total amount of guaranted resources might be gretear than
-	// total amount of resources
+	// If we don't, the total amount of guaranteed resources might be greater
+	// than the total amount of resources
 	// Can use busy loop because this method is called only once
-	for sc.nodeQueue.Len() != 0 {
-	}
+	klog.V(3).Info("wait for nodes sync")
+	sc.WaitForNodesSync()
+	klog.V(3).Info("node sync finished")
 	for i := 0; i < int(sc.nodeWorkers); i++ {
 		go wait.Until(sc.runNodeWorker, 0, stopCh)
 	}
@@ -755,6 +756,14 @@ func (sc *SchedulerCache) Run(stopCh <-chan struct{}) {
 func (sc *SchedulerCache) WaitForCacheSync(stopCh <-chan struct{}) {
 	sc.informerFactory.WaitForCacheSync(stopCh)
 	sc.vcInformerFactory.WaitForCacheSync(stopCh)
+}
+
+func (sc *SchedulerCache) WaitForNodesSync() {
+	ticker := time.NewTicker(time.Millisecond)
+	for sc.nodeQueue.Len() != 0 {
+		<-ticker.C
+	}
+	ticker.Stop()
 }
 
 // findJobAndTask returns job and the task info


### PR DESCRIPTION
Воткнул цикл с таймером, чтобы кэш разгребал все ноды добавленные после синка информеров. Это можно делать циклом тк этот метод вызывается только один раз. Чтобы сделать это лучше нужно отрефакторить слишком много кода + кубовую очередь, чем мне заниматься не хочется. Еще нужно будет завести баг в апстриме