### PR TITLE
MLP-5725 do not take into account nodes and tasks with specific labels/taints into proportion plugin

### DIFF
--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -135,6 +135,7 @@ func (pmpt *Action) Execute(ssn *framework.Session) {
 					}
 
 					if !preemptor.Preemptable {
+						// todo: we should move this logic to our plugin
 						val, ok := task.Pod.Annotations[VolcanoForbidPreemptFromOtherProjectsAnnotation]
 						if !ok || val != "true" {
 							return preemptor.Job != task.Job

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"fmt"
+
 	"k8s.io/klog/v2"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -352,10 +353,6 @@ func (s *Statement) Discard() {
 	for i := len(s.operations) - 1; i >= 0; i-- {
 		op := s.operations[i]
 		op.task.GenerateLastTxContext()
-
-		klog.V(3).Infof("Discard operations on task <%v/%v> on node <%v> with status %s",
-			op.task.Namespace, op.task.Name, op.task.NodeName, op.task.Status)
-
 		switch op.name {
 		case Evict:
 			err := s.unevict(op.task)
@@ -381,10 +378,6 @@ func (s *Statement) Commit() {
 	klog.V(3).Info("Committing operations ...")
 	for _, op := range s.operations {
 		op.task.ClearLastTxContext()
-
-		klog.V(3).Infof("Commit operations on task <%v/%v> on node <%v> with status %s",
-			op.task.Namespace, op.task.Name, op.task.NodeName, op.task.Status)
-
 		switch op.name {
 		case Evict:
 			err := s.evict(op.task, op.reason)

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"fmt"
-
 	"k8s.io/klog/v2"
 
 	"volcano.sh/volcano/pkg/scheduler/api"
@@ -353,6 +352,10 @@ func (s *Statement) Discard() {
 	for i := len(s.operations) - 1; i >= 0; i-- {
 		op := s.operations[i]
 		op.task.GenerateLastTxContext()
+
+		klog.V(3).Infof("Discard operations on task <%v/%v> on node <%v> with status %s",
+			op.task.Namespace, op.task.Name, op.task.NodeName, op.task.Status)
+
 		switch op.name {
 		case Evict:
 			err := s.unevict(op.task)
@@ -378,6 +381,10 @@ func (s *Statement) Commit() {
 	klog.V(3).Info("Committing operations ...")
 	for _, op := range s.operations {
 		op.task.ClearLastTxContext()
+
+		klog.V(3).Infof("Commit operations on task <%v/%v> on node <%v> with status %s",
+			op.task.Namespace, op.task.Name, op.task.NodeName, op.task.Status)
+
 		switch op.name {
 		case Evict:
 			err := s.evict(op.task, op.reason)

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -131,7 +131,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		}
 	}
 
-	klog.V(5).Infof("ignore.node.taint.keys: %v", pp.ignoreTaintKeys)
+	klog.V(2).Infof("%s: %v; %s %v", ignoreNodeTaintKeysOpt, pp.ignoreTaintKeys, ignoreNodeLabelsOpt, pp.ignoreNodeLabels)
 
 	return pp
 }

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -146,6 +146,7 @@ func (pp *proportionPlugin) enableTaskInProportion(info *api.TaskInfo) bool {
 			for _, taskExpressionValue := range expression.Values {
 				for _, ignoreValue := range ignoreValues {
 					if taskExpressionValue == ignoreValue {
+						klog.V(2).Infof("ignore task %s in proportion plugin by affinity %s", info.Name, expression.Key)
 						return false
 					}
 				}
@@ -164,7 +165,7 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 	for _, taint := range node.Node.Spec.Taints {
 		for _, ignoreTaintKey := range pp.ignoreTaintKeys {
 			if taint.Key == ignoreTaintKey {
-				klog.V(2).Infof("ignore node %s proportion plugin by taint %s", node.Name, taint.Key)
+				klog.V(2).Infof("ignore node %s in proportion plugin by taint %s", node.Name, taint.Key)
 				return false
 			}
 		}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -46,7 +46,7 @@ type proportionPlugin struct {
 	totalNotAllocatedResources *api.Resource
 	queueOpts                  map[api.QueueID]*queueAttr
 
-	ignoreTaintsKeys []string
+	ignoreTaintKeys  []string
 	ignoreNodeLabels map[string][]string
 
 	// Arguments given for the plugin
@@ -97,7 +97,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		totalNotAllocatedResources: api.EmptyResource(),
 		queueOpts:                  map[api.QueueID]*queueAttr{},
 
-		ignoreTaintsKeys: []string{},
+		ignoreTaintKeys:  []string{},
 		ignoreNodeLabels: map[string][]string{},
 
 		pluginArguments: arguments,
@@ -105,11 +105,13 @@ func New(arguments framework.Arguments) framework.Plugin {
 
 	if ignoreNodeTaintKeysI, ok := arguments[ignoreNodeTaintKeysOpt]; ok {
 		if ignoreNodeTaintKeys, ok := ignoreNodeTaintKeysI.([]string); ok {
-			pp.ignoreTaintsKeys = ignoreNodeTaintKeys
+			pp.ignoreTaintKeys = ignoreNodeTaintKeys
+		} else {
+			klog.V(2).Infof("real type of ignoreNodeTaintKeys is %T", ignoreNodeTaintKeysI)
 		}
 	}
 
-	klog.V(2).Infof("The total resource is %v", pp.ignoreTaintsKeys)
+	klog.V(2).Infof("ignore taint keys %v", pp.ignoreTaintKeys)
 
 	return pp
 }
@@ -158,7 +160,7 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 	}
 
 	for _, taint := range node.Node.Spec.Taints {
-		for _, ignoreTaintKey := range pp.ignoreTaintsKeys {
+		for _, ignoreTaintKey := range pp.ignoreTaintKeys {
 			if taint.Key == ignoreTaintKey {
 				return false
 			}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -110,12 +110,10 @@ func New(arguments framework.Arguments) framework.Plugin {
 					pp.ignoreTaintKeys = append(pp.ignoreTaintKeys, taintKey)
 				}
 			}
-		} else {
-			klog.V(2).Infof("real type of ignoreNodeTaintKeys is %T", ignoreNodeTaintKeysI)
 		}
 	}
 
-	klog.V(2).Infof("ignore taint keys %v", pp.ignoreTaintKeys)
+	klog.V(5).Infof("ignore.node.taint.keys: %v", pp.ignoreTaintKeys)
 
 	return pp
 }
@@ -166,6 +164,7 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 	for _, taint := range node.Node.Spec.Taints {
 		for _, ignoreTaintKey := range pp.ignoreTaintKeys {
 			if taint.Key == ignoreTaintKey {
+				klog.V(2).Infof("ignore node %s proportion plugin by taint %s", node.Name, taint.Key)
 				return false
 			}
 		}
@@ -200,7 +199,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 	}
 
-	klog.V(4).Infof("The total resource is <%v>", pp.totalResource)
+	klog.V(2).Infof("The total resource in proportion plugin <%v>, in cluster <%v>", pp.totalResource, ssn.TotalResource)
 	for _, queue := range ssn.Queues {
 		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
 			continue

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -113,6 +113,24 @@ func New(arguments framework.Arguments) framework.Plugin {
 		}
 	}
 
+	if ignoreNodeLabelsI, ok := arguments[ignoreNodeLabelsOpt]; ok {
+		if ignoreNodeLabels, ok := ignoreNodeLabelsI.(map[string][]any); ok {
+			for labelName, labelValues := range ignoreNodeLabels {
+				if _, ok := pp.ignoreNodeLabels[labelName]; !ok {
+					pp.ignoreNodeLabels[labelName] = []string{}
+				}
+
+				for _, labelValueI := range labelValues {
+					if labelValue, ok := labelValueI.(string); ok {
+						pp.ignoreNodeLabels[labelName] = append(pp.ignoreNodeLabels[labelName], labelValue)
+					}
+				}
+			}
+		} else {
+			klog.V(2).Infof("ignoreNodeLabels type %T", ignoreNodeLabels)
+		}
+	}
+
 	klog.V(5).Infof("ignore.node.taint.keys: %v", pp.ignoreTaintKeys)
 
 	return pp

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -127,11 +127,11 @@ func New(arguments framework.Arguments) framework.Plugin {
 				}
 			}
 		} else {
-			klog.V(2).Infof("ignoreNodeLabels type %T", ignoreNodeLabels)
+			klog.V(2).Infof("ignoreNodeLabels type %T", ignoreNodeLabelsI)
 		}
 	}
 
-	klog.V(2).Infof("%s: %v; %s %v", ignoreNodeTaintKeysOpt, pp.ignoreTaintKeys, ignoreNodeLabelsOpt, pp.ignoreNodeLabels)
+	klog.V(2).Infof("%s: %v; %s: %v", ignoreNodeTaintKeysOpt, pp.ignoreTaintKeys, ignoreNodeLabelsOpt, pp.ignoreNodeLabels)
 
 	return pp
 }

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -17,9 +17,10 @@ limitations under the License.
 package proportion
 
 import (
-	"k8s.io/klog/v2"
 	"math"
 	"reflect"
+
+	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -240,7 +241,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		}
 	}
 
-	klog.V(2).Infof("The total resource in proportion plugin <%v>, in cluster <%v>", pp.totalResource, ssn.TotalResource)
+	klog.V(4).Infof("The total resource in proportion plugin <%v>, in cluster <%v>", pp.totalResource, ssn.TotalResource)
 	for _, queue := range ssn.Queues {
 		if len(queue.Queue.Spec.Guarantee.Resource) == 0 {
 			continue

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -156,10 +156,10 @@ func (pp *proportionPlugin) enableTaskInProportion(info *api.TaskInfo) bool {
 		info.Pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
 		return true
 	}
-	tersm := info.Pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	terms := info.Pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 
 	// task has node affinity on ignore node
-	for _, term := range tersm {
+	for _, term := range terms {
 		for _, expression := range term.MatchExpressions {
 			if expression.Operator != v1.NodeSelectorOpIn {
 				continue

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -173,7 +173,7 @@ func (pp *proportionPlugin) enableTaskInProportion(info *api.TaskInfo) bool {
 			for _, taskExpressionValue := range expression.Values {
 				for _, ignoreValue := range ignoreValues {
 					if taskExpressionValue == ignoreValue {
-						klog.V(4).Infof("ignore task %s in proportion plugin by affinity %s", info.Name, expression.Key)
+						klog.V(3).Infof("ignore task %s in proportion plugin by affinity %s", info.Name, expression.Key)
 						return false
 					}
 				}
@@ -192,7 +192,7 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 	for _, taint := range node.Node.Spec.Taints {
 		for _, ignoreTaintKey := range pp.ignoreTaintKeys {
 			if taint.Key == ignoreTaintKey {
-				klog.V(4).Infof("ignore node %s in proportion plugin by taint %s", node.Name, taint.Key)
+				klog.V(3).Infof("ignore node %s in proportion plugin by taint %s", node.Name, taint.Key)
 				return false
 			}
 		}
@@ -206,7 +206,7 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 
 		for _, ignoreValue := range ignoreValues {
 			if value == ignoreValue {
-				klog.V(4).Infof("ignore node %s in proportion plugin by label %s with value %s", node.Name, name, value)
+				klog.V(3).Infof("ignore node %s in proportion plugin by label %s with value %s", node.Name, name, value)
 				return false
 			}
 		}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -456,11 +456,11 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		return 1
 	})
 
-	// todo: (MLP-5725)
-	// доработки связанные с EnableTaskInProportion не были сделаны в этом методе, так как:
-	// 1) MLP-5725 - блокер и нет времени разбираться
-	// 2) reclaime action выключен
 	ssn.AddReclaimableFn(pp.Name(), func(reclaimer *api.TaskInfo, reclaimees []*api.TaskInfo) ([]*api.TaskInfo, int) {
+		if !pp.enableTaskInProportion(reclaimer) {
+			return reclaimees, util.Permit
+		}
+
 		var victims []*api.TaskInfo
 		allocations := map[api.QueueID]*api.Resource{}
 
@@ -532,10 +532,6 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 		return allocatable
 	})
 
-	// todo: (MLP-5725)
-	// доработки связанные с EnableTaskInProportion не были сделаны в этом методе, так как:
-	// 1) MLP-5725 - блокер и нет времени разбираться
-	// 2) в нашей конфигурации `enableJobEnqueued: false`
 	ssn.AddJobEnqueueableFn(pp.Name(), func(obj interface{}) int {
 		job := obj.(*api.JobInfo)
 		queueID := job.Queue

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -114,10 +114,20 @@ func New(arguments framework.Arguments) framework.Plugin {
 	}
 
 	if ignoreNodeLabelsI, ok := arguments[ignoreNodeLabelsOpt]; ok {
-		if ignoreNodeLabels, ok := ignoreNodeLabelsI.(map[string][]any); ok {
-			for labelName, labelValues := range ignoreNodeLabels {
+		if ignoreNodeLabels, ok := ignoreNodeLabelsI.(map[any]any); ok {
+			for labelNameI, labelValuesI := range ignoreNodeLabels {
+				labelName, ok := labelNameI.(string)
+				if !ok {
+					continue
+				}
+
 				if _, ok := pp.ignoreNodeLabels[labelName]; !ok {
 					pp.ignoreNodeLabels[labelName] = []string{}
+				}
+
+				labelValues, ok := labelValuesI.([]any)
+				if !ok {
+					continue
 				}
 
 				for _, labelValueI := range labelValues {
@@ -126,8 +136,6 @@ func New(arguments framework.Arguments) framework.Plugin {
 					}
 				}
 			}
-		} else {
-			klog.V(2).Infof("ignoreNodeLabels type %T", ignoreNodeLabelsI)
 		}
 	}
 

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -139,7 +139,7 @@ func New(arguments framework.Arguments) framework.Plugin {
 		}
 	}
 
-	klog.V(2).Infof("%s: %v; %s: %v", ignoreNodeTaintKeysOpt, pp.ignoreTaintKeys, ignoreNodeLabelsOpt, pp.ignoreNodeLabels)
+	klog.V(5).Infof("%s: %v; %s: %v", ignoreNodeTaintKeysOpt, pp.ignoreTaintKeys, ignoreNodeLabelsOpt, pp.ignoreNodeLabels)
 
 	return pp
 }
@@ -172,7 +172,7 @@ func (pp *proportionPlugin) enableTaskInProportion(info *api.TaskInfo) bool {
 			for _, taskExpressionValue := range expression.Values {
 				for _, ignoreValue := range ignoreValues {
 					if taskExpressionValue == ignoreValue {
-						klog.V(2).Infof("ignore task %s in proportion plugin by affinity %s", info.Name, expression.Key)
+						klog.V(4).Infof("ignore task %s in proportion plugin by affinity %s", info.Name, expression.Key)
 						return false
 					}
 				}
@@ -191,7 +191,21 @@ func (pp *proportionPlugin) enableNodeInProportion(node *api.NodeInfo) bool {
 	for _, taint := range node.Node.Spec.Taints {
 		for _, ignoreTaintKey := range pp.ignoreTaintKeys {
 			if taint.Key == ignoreTaintKey {
-				klog.V(2).Infof("ignore node %s in proportion plugin by taint %s", node.Name, taint.Key)
+				klog.V(4).Infof("ignore node %s in proportion plugin by taint %s", node.Name, taint.Key)
+				return false
+			}
+		}
+	}
+
+	for name, value := range node.Node.Labels {
+		ignoreValues, ok := pp.ignoreNodeLabels[name]
+		if !ok {
+			continue
+		}
+
+		for _, ignoreValue := range ignoreValues {
+			if value == ignoreValue {
+				klog.V(4).Infof("ignore node %s in proportion plugin by label %s with value %s", node.Name, name, value)
 				return false
 			}
 		}

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -104,8 +104,12 @@ func New(arguments framework.Arguments) framework.Plugin {
 	}
 
 	if ignoreNodeTaintKeysI, ok := arguments[ignoreNodeTaintKeysOpt]; ok {
-		if ignoreNodeTaintKeys, ok := ignoreNodeTaintKeysI.([]string); ok {
-			pp.ignoreTaintKeys = ignoreNodeTaintKeys
+		if ignoreNodeTaintKeys, ok := ignoreNodeTaintKeysI.([]any); ok {
+			for _, taintKeyI := range ignoreNodeTaintKeys {
+				if taintKey, ok := taintKeyI.(string); ok {
+					pp.ignoreTaintKeys = append(pp.ignoreTaintKeys, taintKey)
+				}
+			}
 		} else {
 			klog.V(2).Infof("real type of ignoreNodeTaintKeys is %T", ignoreNodeTaintKeysI)
 		}


### PR DESCRIPTION
не учитываем ноды и таски со специфичными лейблами при подсчете ресурсов. нужно чтобы ввести а30 и н100 и не сломать квоты в кластере. также доработка позволит нормально не учитывать в квоте с нодами с тейнтами, как например testing 