### PR TITLE
MLP-5001: override BestNodeFn and add log with nodes and scores

### DIFF
--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -18,6 +18,7 @@ package allocate
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -215,13 +216,15 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			}
 
 			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
-
 			var predicateNodeNames []nodeInfo
 			for score, nodes := range nodeScores {
 				for _, node := range nodes {
 					predicateNodeNames = append(predicateNodeNames, nodeInfo{NodeName: node.Name, Score: score})
 				}
 			}
+			sort.Slice(predicateNodeNames, func(i, j int) bool {
+				return predicateNodeNames[i].Score < predicateNodeNames[j].Score
+			})
 
 			klog.V(3).Infof("predicated nodes %v for task %s/%s", predicateNodeNames, task.Namespace, task.Name)
 

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -214,12 +214,15 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 				break
 			}
 
-			var predicateNodeNames []string
-			for _, node := range predicateNodes {
-				predicateNodeNames = append(predicateNodeNames, node.Name)
+			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
+
+			var predicateNodeNames []nodeInfo
+			for score, nodes := range nodeScores {
+				for _, node := range nodes {
+					predicateNodeNames = append(predicateNodeNames, nodeInfo{NodeName: node.Name, Score: score})
+				}
 			}
 
-			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
 			klog.V(3).Infof("predicated nodes %v for task %s/%s", predicateNodeNames, task.Namespace, task.Name)
 
 			bestNode := ssn.BestNodeFn(task, nodeScores)
@@ -277,3 +280,8 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 }
 
 func (alloc *Action) UnInitialize() {}
+
+type nodeInfo struct {
+	NodeName string
+	Score    float64
+}

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -216,17 +216,20 @@ func (alloc *Action) Execute(ssn *framework.Session) {
 			}
 
 			nodeScores := util.PrioritizeNodes(task, predicateNodes, ssn.BatchNodeOrderFn, ssn.NodeOrderMapFn, ssn.NodeOrderReduceFn)
-			var predicateNodeNames []nodeInfo
+			var predicateNodeInfo []nodeInfo
 			for score, nodes := range nodeScores {
 				for _, node := range nodes {
-					predicateNodeNames = append(predicateNodeNames, nodeInfo{NodeName: node.Name, Score: score})
+					predicateNodeInfo = append(predicateNodeInfo, nodeInfo{
+						NodeName: node.Name,
+						Score:    score,
+					})
 				}
 			}
-			sort.Slice(predicateNodeNames, func(i, j int) bool {
-				return predicateNodeNames[i].Score < predicateNodeNames[j].Score
+			sort.Slice(predicateNodeInfo, func(i, j int) bool {
+				return predicateNodeInfo[i].Score > predicateNodeInfo[j].Score
 			})
 
-			klog.V(3).Infof("predicated nodes %v for task %s/%s", predicateNodeNames, task.Namespace, task.Name)
+			klog.V(3).Infof("predicated nodes %v for task %s/%s", predicateNodeInfo, task.Namespace, task.Name)
 
 			bestNode := ssn.BestNodeFn(task, nodeScores)
 			if bestNode == nil {

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -634,9 +634,8 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 
 		maxScore = scores[0]
 
-		delta := 0.1
 		for _, score := range scores {
-			if 1.0-score/maxScore > delta {
+			if 1.0-score/maxScore > pp.allowedOffsetFromBestNodeScore {
 				continue
 			}
 

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -627,12 +627,14 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 			return scores[i] > scores[j]
 		})
 
-		maxScore := 1.0
 		if len(scores) == 0 {
 			return nil
 		}
 
-		maxScore = scores[0]
+		maxScore := scores[0]
+		if maxScore == 0 {
+			maxScore = 1
+		}
 
 		for _, score := range scores {
 			if 1.0-score/maxScore > pp.allowedDeltaFromBestNodeScore {


### PR DESCRIPTION
- добавил переопределение BestNodeFn

потребность: хочется не делать лишних вытеснений, если задача может зашедулиться на ноду без них, но только в случае если их score не сильно отличается

реализация: идем по всем scores от возрастания к убыванию. если нормированный score отличается от максимального меньше чем на delta и мы можем зашедулиться на ноду без вытеснения, то используем эту ноду

- добавил в лог все подходящие под задачу ноды с их scores