### PR TITLE
feat: MLP-5337: allow set custom ports for network policy

### DIFF
--- a/pkg/controllers/job/plugins/svc/svc.go
+++ b/pkg/controllers/job/plugins/svc/svc.go
@@ -305,7 +305,7 @@ func (sp *servicePlugin) createNetworkPolicyIfNotExist(job *batch.Job) error {
 			for _, spec := range sp.networkPolicyIngressPortsSpecs {
 				portPolicy, err := parseNetworkPolicyPort(spec)
 				if err != nil {
-					klog.V(3).Infof("Failed to build network policy for Job <%s/%s>: %v", job.Namespace, job.Name, err)
+					klog.V(3).Infof("failed to parse network policy ports from plugin settings for Job <%s/%s>: %v", job.Namespace, job.Name, err)
 					return err
 				}
 


### PR DESCRIPTION
Hi folks!

I've decided to add an additional flag to the svc plugin in order to specify additional ports in the ingress section when creating a network policy.

